### PR TITLE
Fix 'cannot spawn git' error

### DIFF
--- a/compat/mingw.c
+++ b/compat/mingw.c
@@ -835,7 +835,7 @@ static void free_path_split(char **path)
 static char *lookup_prog(const char *dir, const char *cmd, int isexe, int exe_only)
 {
 	char path[MAX_PATH];
-	snprintf(path, sizeof(path), "%s/%s.exe", dir, cmd);
+	snprintf(path, sizeof(path), "%s\\%s.exe", dir, cmd);
 
 	if (!isexe && access(path, F_OK) == 0)
 		return xstrdup(path);


### PR DESCRIPTION
On Windows XP3 in git bash (Git-1.7.6-preview20110708.exe)
git clone git@github.com:octocat/Spoon-Knife.git
cd Spoon-Knife
git gui
menu Remote\Fetch from\origin  
error: cannot spawn git: No such file or directory
error: could not run rev-list  

if i'm run
git fetch --all
it worked normal in git bash or gitgui tools

In second version CreateProcess get 'C:\Git\libexec\git-core/git.exe'
in first version - C:/Git/libexec/git-core/git.exe and not executes (unix slashes)

after fixing to C:\Git\libexec\git-core\git.exe or C:/Git/libexec/git-core\git.exe it works normal
