### PR TITLE
fix build: error: conflicting types for 'mingw_exec...

### DIFF
--- a/compat/mingw.c
+++ b/compat/mingw.c
@@ -1233,7 +1233,7 @@ static int try_shell_exec(const char *cmd, char *const *argv)
 	return pid;
 }
 
-void mingw_execv(const char *cmd, char *const *argv)
+int mingw_execv(const char *cmd, char *const *argv)
 {
 	/* check if git_command is a shell script */
 	if (!try_shell_exec(cmd, argv)) {
@@ -1241,11 +1241,12 @@ void mingw_execv(const char *cmd, char *const *argv)
 
 		pid = mingw_spawnv(cmd, (const char **)argv, 0);
 		if (pid < 0)
-			return;
+			return -1;
 		if (waitpid(pid, &status, 0) < 0)
 			status = 255;
 		exit(status);
 	}
+	return -1;
 }
 
 int mingw_execvp(const char *cmd, char *const *argv)


### PR DESCRIPTION
fixes the build

compat/mingw.c:1236: error: conflicting types for 'mingw_execv'
compat/../compat/mingw.h:294: note: previous declaration of 'mingw_execv' was here
make: **\* [compat/mingw.o] Error 1
