### PR TITLE
Sleep 1 millisecond in poll() to avoid busy wait

### DIFF
--- a/compat/win32/poll.c
+++ b/compat/win32/poll.c
@@ -597,7 +597,9 @@ restart:
 
   if (!rc && timeout == INFTIM)
     {
-      SwitchToThread();
+      /* Sleep 1 millisecond to avoid busy wait */
+      SleepEx(1, TRUE);
+
       goto restart;
     }
 


### PR DESCRIPTION
Even though it's a very short sleep, it's enough to eliminate the high CPU usage, without causing any noticeable slow down.

More discussions on https://groups.google.com/forum/?fromgroups#!topic/msysgit/CXeizBCmFUE
