### PR TITLE
Added the --large-address-aware linker directive to the makefile.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1339,6 +1339,7 @@ ifneq (,$(findstring MINGW,$(uname_S)))
 	COMPAT_OBJS += compat/mingw.o compat/winansi.o \
 		compat/win32/pthread.o compat/win32/syslog.o \
 		compat/win32/poll.o compat/win32/dirent.o
+	BASIC_LDFLAGS += -Wl,--large-address-aware
 	EXTLIBS += -lws2_32
 	GITLIBS += git.res
 	PTHREAD_LIBS =


### PR DESCRIPTION
This has the effect of increasing the address space from 2GB to 4GB under 64-bit Windows, reducing the likelihood of an "out of memory" error when e.g. repacking a large repository.
All tests in the "devel" branch (as at 27/5/2012) pass with this patch in place.
