### PR TITLE
Fix launching of externals from Unicode paths

### DIFF
--- a/compat/mingw.c
+++ b/compat/mingw.c
@@ -981,14 +981,20 @@ static void free_path_split(char **path)
 static char *lookup_prog(const char *dir, const char *cmd, int isexe, int exe_only)
 {
 	char path[MAX_PATH];
+	wchar_t wpath[MAX_PATH];
 	snprintf(path, sizeof(path), "%s\\%s.exe", dir, cmd);
 
-	if (!isexe && access(path, F_OK) == 0)
+	if (xutftowcs_path(wpath, path) < 0)
+		return NULL;
+
+	if (!isexe && _waccess(wpath, F_OK) == 0)
 		return xstrdup(path);
 	path[strlen(path)-4] = '\0';
-	if ((!exe_only || isexe) && access(path, F_OK) == 0)
-		if (!(GetFileAttributes(path) & FILE_ATTRIBUTE_DIRECTORY))
+	if ((!exe_only || isexe) && _waccess(wpath, F_OK) == 0) {
+
+		if (!(GetFileAttributesW(wpath) & FILE_ATTRIBUTE_DIRECTORY))
 			return xstrdup(path);
+	}
 	return NULL;
 }
 


### PR DESCRIPTION
If Git were installed in a path containing non-ASCII characters,
commands such as git-am and git-submodule, which are implemented as
externals, would fail to launch with the following error:

> fatal: 'am' appears to be a git command, but we were not
> able to execute it. Maybe git-am is broken?

This was due to lookup_prog not being Unicode-aware. It was somehow
missed in 2ee5a1a14ad17ff35f0ad52390a27fbbc41258f3.

Signed-off-by: Adam Roben adam@roben.org
