### PR TITLE
Make non-.exe externals work again

### DIFF
--- a/compat/mingw.c
+++ b/compat/mingw.c
@@ -989,11 +989,12 @@ static char *lookup_prog(const char *dir, const char *cmd, int isexe, int exe_on
 
 	if (!isexe && _waccess(wpath, F_OK) == 0)
 		return xstrdup(path);
-	path[strlen(path)-4] = '\0';
+	wpath[wcslen(wpath)-4] = '\0';
 	if ((!exe_only || isexe) && _waccess(wpath, F_OK) == 0) {
-
-		if (!(GetFileAttributesW(wpath) & FILE_ATTRIBUTE_DIRECTORY))
+		if (!(GetFileAttributesW(wpath) & FILE_ATTRIBUTE_DIRECTORY)) {
+			path[strlen(path)-4] = '\0';
 			return xstrdup(path);
+		}
 	}
 	return NULL;
 }


### PR DESCRIPTION
7ebac8cb94f3a06d3fbdde469414a1443ca45510 made launching of .exe
externals work when installed in Unicode paths. But it broke launching
of non-.exe externals, no matter where they were installed. We now
correctly maintain the UTF-8 and UTF-16 paths in tandem in lookup_prog.

Signed-off-by: Adam Roben adam@roben.org
