### PR TITLE
Fixed gs_do_switch for custom tunnel schemes

### DIFF
--- a/perl/Git/SVN/Ra.pm
+++ b/perl/Git/SVN/Ra.pm
@@ -295,7 +295,7 @@ sub gs_do_switch {
 	my $full_url = add_path_to_url( $self->url, $path );
 	my ($ra, $reparented);
 
-	if ($old_url =~ m#^svn(\+ssh)?://# ||
+	if ($old_url =~ m#^svn(\+\w+)?://# ||
 	    ($full_url =~ m#^https?://# &&
 	     canonicalize_url($full_url) ne $full_url)) {
 		$_[0] = undef;


### PR DESCRIPTION
I've been getting this bug recently:

``` bash
$ g svn fetch
Found possible branch point: svn+xyz://.../trunk => svn+xyz://.../branches/etc, 24743
Found branch parent: (refs/remotes/svn/xap6_ade_reg_split) dd98917ae2e94e414a2a70cf7dfb032aadf89d43
Following parent with do_switch
Malformed network data: Malformed network data at /usr/lib/perl5/site_perl/Git/SVN/Ra.pm line 307
```

This is caused by the custom tunnel protocol, and is rectified by changing the regex for `svn+ssh` to cover all protocols of the form `svn+...`
