### PR TITLE
treat crlf as lf when read credential

### DIFF
--- a/credential.c
+++ b/credential.c
@@ -143,7 +143,7 @@ int credential_read(struct credential *c, FILE *fp)
 {
 	struct strbuf line = STRBUF_INIT;
 
-	while (strbuf_getline(&line, fp, '\n') != EOF) {
+	while (strbuf_getline_with_any_ending(&line, fp) != EOF) {
 		char *key = line.buf;
 		char *value = strchr(key, '=');
 

--- a/strbuf.c
+++ b/strbuf.c
@@ -428,6 +428,15 @@ int strbuf_getline(struct strbuf *sb, FILE *fp, int term)
 	return 0;
 }
 
+int strbuf_getline_with_any_ending(struct strbuf *sb, FILE *fp)
+{
+	if (strbuf_getline(sb, fp, '\n'))
+		return EOF;
+	if (sb->buf[sb->len-1] == '\r')
+		strbuf_setlen(sb, sb->len-1);
+	return 0;
+}
+
 int strbuf_getwholeline_fd(struct strbuf *sb, int fd, int term)
 {
 	strbuf_reset(sb);

--- a/strbuf.h
+++ b/strbuf.h
@@ -160,6 +160,8 @@ extern int strbuf_readlink(struct strbuf *sb, const char *path, size_t hint);
 
 extern int strbuf_getwholeline(struct strbuf *, FILE *, int);
 extern int strbuf_getline(struct strbuf *, FILE *, int);
+/* Read line with Unix endind (lf) or Windows ending (crlf) */
+extern int strbuf_getline_with_any_ending(struct strbuf *, FILE *);
 extern int strbuf_getwholeline_fd(struct strbuf *, int, int);
 
 extern void stripspace(struct strbuf *buf, int skip_comments);


### PR DESCRIPTION
Allow to use Windows style crlf ending in a data file when interacting from scripts with the git credential interface (git credential fill|approve|reject)

Instead of
https://github.com/msysgit/git/pull/75
