### PR TITLE
Add Windows long path support

### DIFF
--- a/compat/win32/dirent.c
+++ b/compat/win32/dirent.c
@@ -73,9 +73,13 @@ DIR *dirent_opendir(const char *name)
 	if ((len = xutftowcs_canonical_path(pattern, name)) < 0)
 		return NULL;
 
-	/* append optional '/' and wildcard '*' */
+	/*
+	 * append optional '\' and wildcard '*'
+	 * note: when using "\\?\" as a prefix for long paths,
+	 * we cannot expect Windows to remap '/' to '\' for us.
+	 */
 	if (len && !is_dir_sep(pattern[len - 1]))
-		pattern[len++] = '/';
+		pattern[len++] = '\\';
 	pattern[len++] = '*';
 	pattern[len] = 0;
 

--- a/git-compat-util.h
+++ b/git-compat-util.h
@@ -272,6 +272,10 @@ extern char *gitbasename(char *);
 #define has_dos_drive_prefix(path) 0
 #endif
 
+#ifndef has_win_abspath_prefix
+#define has_win_abspath_prefix(path) 0
+#endif
+
 #ifndef offset_1st_component
 #define offset_1st_component(path) (is_dir_sep((path)[0]))
 #endif

--- a/path.c
+++ b/path.c
@@ -619,6 +619,12 @@ int normalize_path_copy_len(char *dst, const char *src, int *prefix_len)
 {
 	char *dst0;
 
+	/*
+	 * If path contains "\\?\", we can skip this while copying.
+	 * We will re-add this later if necessary.
+	 */
+	if (has_win_abspath_prefix(src))
+		src += 4;
 	if (has_dos_drive_prefix(src)) {
 		*dst++ = *src++;
 		*dst++ = *src++;


### PR DESCRIPTION
This adds support for Windows long paths through the "\?\"
namespace.  Note that some internal Windows APIs don't support
longer paths (_wmktemp, _wchdir), and shells don't like the "\?\"
namespace, so the internal length may still be limited.

Thanks-to: nitram509 maki@bitkings.de
Signed-off-by: Doug Kelly dougk.ff7@gmail.com
