### PR TITLE
Fix handling of long recursive paths

### DIFF
--- a/compat/mingw.h
+++ b/compat/mingw.h
@@ -455,29 +455,7 @@ static inline int xutftowcs_path(wchar_t *wcs, const char *utf)
  * fails with ENAMETOOLONG if input string is too long.  This version
  * also canonicalizes the path before returning.
  */
-static inline int xutftowcs_canonical_path(wchar_t *wcs, const char *utf)
-{
-	wchar_t tmp[SHRT_MAX];
-	int result;
-	result = xutftowcsn(tmp, utf, SHRT_MAX, -1);
-	if (result < 0 && errno == ERANGE)
-		errno = ENAMETOOLONG;
-	else if (wcsncmp(tmp, L"nul", 4) == 0 )
-		wcsncpy(wcs, tmp, 4);
-	else {
-		wchar_t tmp2[SHRT_MAX];
-		GetFullPathNameW(tmp, SHRT_MAX, tmp2, NULL);
-		if (wcslen(tmp2) < MAX_PATH)
-			wcsncpy(wcs, tmp2, MAX_PATH - 1);
-		else {
-			result = -1;
-			errno = ENAMETOOLONG;
-		}
-	}
-	if (result != -1)
-		result = wcslen(wcs);
-	return result;
-}
+int xutftowcs_canonical_path(wchar_t *wcs, const char *utf);
 
 /**
  * Converts UTF-16LE encoded string to UTF-8.

--- a/t/t7410-submodule-long-path.sh
+++ b/t/t7410-submodule-long-path.sh
@@ -1,0 +1,101 @@
+#!/bin/sh
+#
+# Copyright (c) 2013 Doug Kelly
+#
+
+test_description='Test submodules with a path near PATH_MAX
+
+This test verifies that "git submodule" initialization, update and clones work, including with recursive submodules and paths approaching PATH_MAX (260 characters on Windows)
+'
+
+TEST_NO_CREATE_REPO=1
+. ./test-lib.sh
+
+longpath=""
+for (( i=0; i<4; i++ )); do
+	longpath="0123456789abcdefghijklmnopqrstuvwxyz$longpath"
+done
+# Pick a substring maximum of 90 characters
+# This should be good, since we'll add on a lot for temp directories
+export longpath=${longpath:0:90}
+
+test_expect_success 'submodule with a long path' '
+	git init --bare remote &&
+	test_create_repo bundle1 &&
+	(
+		cd bundle1 &&
+		test_commit "shoot" &&
+		git rev-parse --verify HEAD >../expect
+	) &&
+	mkdir home &&
+	(
+		cd home &&
+		git clone ../remote test &&
+		cd test &&
+		git submodule add ../bundle1 $longpath &&
+		test_commit "sogood" &&
+		(
+			cd $longpath &&
+			git rev-parse --verify HEAD >actual &&
+			test_cmp ../../../expect actual
+		) &&
+		git push origin master
+	) &&
+	mkdir home2 &&
+	(
+		cd home2 &&
+		git clone ../remote test &&
+		cd test &&
+		git checkout master &&
+		git submodule update --init &&
+		(
+			cd $longpath &&
+			git rev-parse --verify HEAD >actual &&
+			test_cmp ../../../expect actual
+		)
+	)
+'
+
+test_expect_success 'recursive submodule with a long path' '
+	git init --bare super &&
+	test_create_repo child &&
+	(
+		cd child &&
+		test_commit "shoot" &&
+		git rev-parse --verify HEAD >../expect
+	) &&
+	test_create_repo parent &&
+	(
+		cd parent &&
+		git submodule add ../child $longpath &&
+		test_commit "aim"
+	) &&
+	mkdir home3 &&
+	(
+		cd home3 &&
+		git clone ../super test &&
+		cd test &&
+		git submodule add ../parent foo &&
+		git submodule update --init --recursive
+		test_commit "sogood" &&
+		(
+			cd foo/$longpath &&
+			git rev-parse --verify HEAD >actual &&
+			test_cmp ../../../../expect actual
+		) &&
+		git push origin master
+	) &&
+	mkdir home4 &&
+	(
+		cd home4 &&
+		git clone ../super test --recursive &&
+		(
+			cd test/foo/$longpath &&
+			git rev-parse --verify HEAD >actual &&
+			test_cmp ../../../../expect actual
+		)
+	)
+'
+unset longpath
+
+test_done


### PR DESCRIPTION
The commit in msysgit/git#86 attempted to better handle recursive
paths that would exceed MAX_PATH on Windows, since the paths would
be too long to fit in Git's buffers when expressed relatively,
but could easily fit when reduced back to a canonical path.  This
also adds a testcase that was lacking from the original commit that
attempts to describe the behavior.

Also, msysgit/git#111 attempted to work around a bug that
msysgit/git#86 introduced.  This partially reverts the change,
but it keeps the concept of checking for the special device names
using string lists as a better way to detect if a path should
not be manipulated.

Finally, it is not documented clearly in the Windows API, but
GetFullPathNameW() actually may require a string longer than the
actual output length, so we use a temp buffer that is twice as
long.  Windows is able to resolve the relative path, even if
the relative path is longer than 260 characters, since the
function doesn't actually check for a valid name. There is a bit
of a red herring that it is limited to MAX_PATH characters, and
while that may be true of the input string (such as, you cannot
have a relative path longer than MAX_PATH), the temporary space
needed may be longer, but the output still needs to be less than
MAX_PATH characters without using "\?\".

Signed-off-by: Doug Kelly dougk.ff7@gmail.com
