### PR TITLE
use system encoding utf-8 instead of encode convert

### DIFF
--- a/git-gui/git-gui.sh
+++ b/git-gui/git-gui.sh
@@ -547,9 +547,13 @@ proc git {args} {
 	set args [lrange $args 1 end]
 
 	_trace_exec [concat $opt $cmdp $args]
-	set result [eval exec $opt $cmdp $args]
 	if {[encoding system] != "utf-8"} {
-		set result [encoding convertfrom utf-8 [encoding convertto $result]]
+		set old_system_encoding [encoding system]
+		encoding system utf-8
+	}
+	set result [eval exec $opt $cmdp $args]
+	if {[info exist old_system_encoding]} {
+		encoding system $old_system_encoding
 	}
 	if {$::_trace} {
 		puts stderr "< $result"


### PR DESCRIPTION
as git will always return utf-8 encoded string (True?), set system encoding to utf-8 and then restore to avoid encoding convert(which do not work correctly in NON english), only when [encoding system]!=utf-8
