### PR TITLE
Fix test suite issues with iso8859-1 parameters 

### DIFF
--- a/t/t4041-diff-submodule-option.sh
+++ b/t/t4041-diff-submodule-option.sh
@@ -23,8 +23,10 @@ add_file () {
 			echo "$name" >"$name" &&
 			git add "$name" &&
 			test_tick &&
-			msg_added_iso88591=$(echo "Add $name ($added $name)" | iconv -f utf-8 -t iso8859-1) &&
-			git -c 'i18n.commitEncoding=iso8859-1' commit -m "$msg_added_iso88591"
+			# "git commit -m" would break MinGW, as Windows refuse to pass
+			# iso8859-1 encoded parameter to git.
+			echo "Add $name ($added $name)" | iconv -f utf-8 -t iso8859-1 |
+			git -c 'i18n.commitEncoding=iso8859-1' commit -F -
 		done >/dev/null &&
 		git rev-parse --short --verify HEAD
 	)

--- a/t/t4205-log-pretty-formats.sh
+++ b/t/t4205-log-pretty-formats.sh
@@ -28,8 +28,9 @@ test_expect_success 'set up basic repos' '
 	git add foo &&
 	test_tick &&
 	git config i18n.commitEncoding iso8859-1 &&
-	commit_msg iso8859-1 > commit_msg &&
-	git commit --file commit_msg &&
+	# "git commit -m" would break MinGW, as Windows refuse to pass
+	# iso8859-1 encoded parameter to git.
+	commit_msg iso8859-1 | git commit -F - &&
 	git add bar &&
 	test_tick &&
 	git commit -m "add bar" &&

--- a/t/t7102-reset.sh
+++ b/t/t7102-reset.sh
@@ -41,7 +41,9 @@ test_expect_success 'creating initial files and commits' '
 
 	echo "1st line 2nd file" >secondfile &&
 	echo "2nd line 2nd file" >>secondfile &&
-	git -c "i18n.commitEncoding=iso8859-1" commit -a -m "$(commit_msg iso8859-1)" &&
+	# "git commit -m" would break MinGW, as Windows refuse to pass
+	# iso8859-1 encoded parameter to git.
+	commit_msg iso8859-1 | git -c "i18n.commitEncoding=iso8859-1" commit -a -F - &&
 	head5=$(git rev-parse --verify HEAD)
 '
 # git log --pretty=oneline # to see those SHA1 involved
@@ -331,7 +333,9 @@ test_expect_success 'redoing the last two commits should succeed' '
 
 	echo "1st line 2nd file" >secondfile &&
 	echo "2nd line 2nd file" >>secondfile &&
-	git -c "i18n.commitEncoding=iso8859-1" commit -a -m "$(commit_msg iso8859-1)" &&
+	# "git commit -m" would break MinGW, as Windows refuse to pass
+	# iso8859-1 encoded parameter to git.
+	commit_msg iso8859-1 | git -c "i18n.commitEncoding=iso8859-1" commit -a -F - &&
 	check_changes $head5
 '
 


### PR DESCRIPTION
I fixed the two failing test scripts following Karsten's hint from here:
2482bc9#commitcomment-5946968

I had this as one commit originally (kasal:test-fix) but changed that to contain reverts.

I found a similar fix in t4205, so I updated it and added a comment.

Out of curiosity:
What about 1.9.1? Are you going to rebase the msysgit-specific patches? Should the reverted ones get dropped?
