### PR TITLE
t7407: simplify funny CR workaround

### DIFF
--- a/t/t7407-submodule-foreach.sh
+++ b/t/t7407-submodule-foreach.sh
@@ -77,10 +77,6 @@ test_expect_success 'test basic "submodule foreach" usage' '
 		git config foo.bar zar &&
 		git submodule foreach "git config --file \"\$toplevel/.git/config\" foo.bar"
 	) &&
-	if test_have_prereq MINGW
-	then
-		dos2unix actual
-	fi &&
 	test_i18ncmp expect actual
 '
 
@@ -178,10 +174,6 @@ test_expect_success 'test messages from "foreach --recursive"' '
 		cd clone2 &&
 		git submodule foreach --recursive "true" > ../actual
 	) &&
-	if test_have_prereq MINGW
-	then
-		dos2unix actual
-	fi &&
 	test_i18ncmp expect actual
 '
 
@@ -200,11 +192,7 @@ test_expect_success 'test "foreach --quiet --recursive"' '
 		cd clone2 &&
 		git submodule foreach -q --recursive "echo \$name-\$path" > ../actual
 	) &&
-	if test_have_prereq MINGW
-	then
-		dos2unix actual
-	fi &&
-	test_cmp expect actual
+	test_cmp_text expect actual
 '
 
 test_expect_success 'use "update --recursive" to checkout all submodules' '
@@ -251,10 +239,6 @@ test_expect_success 'test "status --recursive"' '
 		cd clone3 &&
 		git submodule status --recursive > ../actual
 	) &&
-	if test_have_prereq MINGW
-	then
-		dos2unix actual
-	fi &&
 	test_cmp expect actual
 '
 


### PR DESCRIPTION
The dos2unix calls can be removed:
- in two cases, current git-submodule.sh produces CR-free output
- in one case, it is enough to use test_cmp_text instead of test_cmp
- in one case, test_i18ncmp calls test_cmp_text for us
