### PR TITLE
fixup! Windows: Always normalize paths to Windows-style

### DIFF
--- a/git-sh-setup.sh
+++ b/git-sh-setup.sh
@@ -304,8 +304,10 @@ case $(uname -s) in
 	find () {
 		/usr/bin/find "$@"
 	}
-	# Let pwd always return the uniqe real windows path
-	alias pwd='pwd -W'
+	# git sees Windows-style pwd
+	pwd () {
+		builtin pwd -W
+	}
 	is_absolute_path () {
 		case "$1" in
 		[/\\]* | [A-Za-z]:*)


### PR DESCRIPTION
Originally, there was commit 64a8a03, adding an alias for `pwd -W`

In its first rebase, 6583d28, upstream already had a shell function doing the same.
The conflict was resolved by keeping "our" version - the alias, but why?
Is there any chance to convince upstream to accept it?  If not, I would suggest to go with the shell function, which can be done by accepting this PR.
