### PR TITLE
fixup! Merge 'install-wincred' into HEAD

### DIFF
--- a/contrib/credential/wincred/Makefile
+++ b/contrib/credential/wincred/Makefile
@@ -1,20 +1,14 @@
+all: git-credential-wincred.exe
+
+CC = gcc
+RM = rm -f
+CFLAGS = -O2 -Wall
+
 -include ../../../config.mak.autogen
 -include ../../../config.mak
 
-prefix ?= /usr/local
-libexecdir ?= $(prefix)/libexec/git-core
-
-INSTALL ?= install
-
-GIT_CREDENTIAL_WINCRED := git-credential-wincred.exe
-
-all: $(GIT_CREDENTIAL_WINCRED)
-
-$(GIT_CREDENTIAL_WINCRED): git-credential-wincred.c
+git-credential-wincred.exe : git-credential-wincred.c
 	$(LINK.c) $^ $(LOADLIBES) $(LDLIBS) -o $@
 
-install: $(GIT_CREDENTIAL_WINCRED)
-	$(INSTALL) -m 755 $(GIT_CREDENTIAL_WINCRED) $(libexecdir)
-
 clean:
-	$(RM) $(GIT_CREDENTIAL_WINCRED)
+	$(RM) git-credential-wincred.exe


### PR DESCRIPTION
Pat's patch to makefile was rejected upstream.  Are there any reasons for it, or could it be dropped?
Stepan
