### PR TITLE
Grep fixes

### DIFF
--- a/builtin/grep.c
+++ b/builtin/grep.c
@@ -875,7 +875,7 @@ int cmd_grep(int argc, const char **argv, const char *prefix)
 			pager += len - 4;
 
 		if (opt.ignore_case && !strcmp("less", pager))
-			string_list_append(&path_list, "-i");
+			string_list_append(&path_list, "-I");
 
 		if (!strcmp("less", pager) || !strcmp("vi", pager)) {
 			struct strbuf buf = STRBUF_INIT;


### PR DESCRIPTION
Revert 31f5ab1 "grep -I: do not bother to read known-binary files", beacuse it is no longer necessary, see
http://article.gmane.org/gmane.comp.version-control.msysgit/20225

Amend 80d7b91 to match the variant accepted upstream, as "less -I" matches the semantics of "git grep -i".
See http://article.gmane.org/gmane.comp.version-control.git/248934
