### PR TITLE
fixup! wincred: add install target and avoid overwriting configured vari...

### DIFF
--- a/contrib/credential/wincred/Makefile
+++ b/contrib/credential/wincred/Makefile
@@ -1,20 +1,22 @@
+all: git-credential-wincred.exe
+
 -include ../../../config.mak.autogen
 -include ../../../config.mak
+
+CC ?= gcc
+RM ?= rm -f
+CFLAGS ?= -O2 -Wall
 
 prefix ?= /usr/local
 libexecdir ?= $(prefix)/libexec/git-core
 
 INSTALL ?= install
 
-GIT_CREDENTIAL_WINCRED := git-credential-wincred.exe
-
-all: $(GIT_CREDENTIAL_WINCRED)
-
-$(GIT_CREDENTIAL_WINCRED): git-credential-wincred.c
+git-credential-wincred.exe : git-credential-wincred.c
 	$(LINK.c) $^ $(LOADLIBES) $(LDLIBS) -o $@
 
-install: $(GIT_CREDENTIAL_WINCRED)
-	$(INSTALL) -m 755 $(GIT_CREDENTIAL_WINCRED) $(libexecdir)
+install: git-credential-wincred.exe
+	$(INSTALL) -m 755 $^ $(libexecdir)
 
 clean:
-	$(RM) $(GIT_CREDENTIAL_WINCRED)
+	$(RM) git-credential-wincred.exe


### PR DESCRIPTION
The original commit has been accepted to junio/pu, as two commits, ccfb5bd and 248b68f
The remaining part is only a matter of style and is not important.
This PR puts our Makefile in sync with the upstream version.
