### PR TITLE
Support long paths v3

### DIFF
--- a/compat/win32/dirent.c
+++ b/compat/win32/dirent.c
@@ -70,7 +70,8 @@ DIR *dirent_opendir(const char *name)
 	dirent_DIR *dir;
 
 	/* convert name to UTF-16 and check length */
-	if ((len = xutftowcs_long_path(pattern, name)) < 0)
+	if ((len = xutftowcs_path_ex(pattern, name, MAX_LONG_PATH, -1,
+			MAX_PATH - 2, core_long_paths)) < 0)
 		return NULL;
 
 	/*


### PR DESCRIPTION
This fixes the bug discussed in (closed) PR #122

To be more specific, the first short commit does fix it, the second one is a cleanup.

I would like to squash both of these with the original long paths patch, so that it could be submitted upstream as one patch.  (That it why I cheekily named the branch kb-long-paths-v3 .)
@kblees, would you agree?
