### PR TITLE
git-gui/gitk: Do not use a Cygwin-specific kill flag on Windows

### DIFF
--- a/git-gui/git-gui.sh
+++ b/git-gui/git-gui.sh
@@ -669,9 +669,7 @@ proc kill_file_process {fd} {
 
 	catch {
 		if {[is_Windows]} {
-			# Use a Cygwin-specific flag to allow killing
-			# native Windows processes
-			exec kill -f $process
+			exec taskkill /pid $process
 		} else {
 			exec kill $process
 		}

--- a/gitk-git/gitk
+++ b/gitk-git/gitk
@@ -445,7 +445,7 @@ proc stop_instance {inst} {
 	set pid [pid $fd]
 
 	if {$::tcl_platform(platform) eq {windows}} {
-	    exec kill -f $pid
+	    exec taskkill /pid $pid
 	} else {
 	    exec kill $pid
 	}


### PR DESCRIPTION
I'm posting this here instead of upstream to get some early feedback from Windows people, and maybe to carry this patch around for a while for testing before submitting it upstream.

Merging this would allow us to get rid of @angavrilov's [patch](https://github.com/msysgit/msysgit/blob/master/src/rt/patches/0004-Added-Cygwin-implementation-of-kill.patch) which makes us ship Cygwin's instead of MSYS' `kill`.
