### PR TITLE
For git.exe alone, use the same HOME directory fallback mechanism as /etc/profile

### DIFF
--- a/compat/mingw.c
+++ b/compat/mingw.c
@@ -2008,13 +2008,20 @@ const char *get_windows_home_directory(void)
 		return home_directory;
 
 	home_directory = getenv("HOME");
-	if (home_directory && *home_directory)
+	if (is_directory(home_directory))
 		return home_directory;
 
 	strbuf_addf(&buf, "%s/%s", getenv("HOMEDRIVE"), getenv("HOMEPATH"));
 	home_directory = strbuf_detach(&buf, NULL);
+	if (is_directory(home_directory))
+		return home_directory;
 
-	return home_directory;
+	home_directory = getenv("USERPROFILE");
+	if (is_directory(home_directory))
+		return home_directory;
+
+	home_directory = NULL;
+	return NULL;
 }
 
 int xutftowcsn(wchar_t *wcs, const char *utfs, size_t wcslen, int utflen)


### PR DESCRIPTION
For git.exe alone, use the same HOME directory fallback mechanism as /etc/profile

This allows the fallback mechanism to work outside Git Bash.