### PR TITLE
MinGW: fix signature of CreateHardLinkA()

### DIFF
--- a/compat/mingw.c
+++ b/compat/mingw.c
@@ -1122,7 +1122,7 @@ static int err_win_to_posix(DWORD winerr)
 
 int link(const char *oldpath, const char *newpath)
 {
-	typedef BOOL (*T)(const char*, const char*, LPSECURITY_ATTRIBUTES);
+	typedef BOOL WINAPI (*T)(LPCTSTR, LPCTSTR, LPSECURITY_ATTRIBUTES);
 	static T create_hard_link = NULL;
 	if (!create_hard_link) {
 		create_hard_link = (T) GetProcAddress(


### PR DESCRIPTION
If the declaration of CreateHardLinkA() does not contain the magic word
"WINAPI", the stack will be clobbered in the error case.

This fixes msysGit issue 204.

Signed-off-by: Johannes Schindelin <johannes.schindelin@gmx.de>